### PR TITLE
add aki27 to font path

### DIFF
--- a/keyboards/aki27/cocot46plus/config.h
+++ b/keyboards/aki27/cocot46plus/config.h
@@ -79,4 +79,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define ADNS5050_CS_PIN           B5
 
 #define POINTING_DEVICE_ROTATION_180
-#define OLED_FONT_H "keyboards/cocot46plus/glcdfont.c"
+#define OLED_FONT_H "keyboards/aki27/cocot46plus/glcdfont.c"


### PR DESCRIPTION
Running `qmk compile -kb aki27/cocot46plus -km default` against updated `master` branch fails with the following error:

```
Compiling: drivers/oled/ssd1306_sh1106.c                                                           In file included from <command-line>:
./keyboards/aki27/cocot46plus/config.h:82:21: fatal error: keyboards/cocot46plus/glcdfont.c: No such file or directory
 #define OLED_FONT_H "keyboards/cocot46plus/glcdfont.c"
```