### PR TITLE
Reduce firmware size by eliminating sin and cos

### DIFF
--- a/keyboards/aki27/cocot46plus/cocot46plus.c
+++ b/keyboards/aki27/cocot46plus/cocot46plus.c
@@ -68,6 +68,7 @@ void pointing_device_init_kb(void) {
 }
 
 
+#ifndef COCOT_SUPPORT_ARBITRARY_ROTATION
 static double sin_degree(int16_t angle) {
     double v[] = {
         0,                           // 0
@@ -98,6 +99,7 @@ static double cos_degree(int16_t angle) {
     }
     return v[i];
 }
+#endif
 
 
 report_mouse_t pointing_device_task_kb(report_mouse_t mouse_report) {
@@ -110,9 +112,15 @@ report_mouse_t pointing_device_task_kb(report_mouse_t mouse_report) {
     float sensitivity_multiplier = 1.5; // Sensitivity adjustment multiplier
 
     // Apply rotation angle adjustment
+#ifndef COCOT_SUPPORT_ARBITRARY_ROTATION
     int16_t angle = -angle_array[cocot_config.rotation_angle];
     float rotated_x = mouse_report.x * cos_degree(angle) - mouse_report.y * sin_degree(angle);
     float rotated_y = mouse_report.x * sin_degree(angle) + mouse_report.y * cos_degree(angle);
+#else
+    double rad = (double)angle_array[cocot_config.rotation_angle] * (M_PI / 180) * -1;
+    float rotated_x = mouse_report.x * cos(rad) - mouse_report.y * sin(rad);
+    float rotated_y = mouse_report.x * sin(rad) + mouse_report.y * cos(rad);
+#endif
 
     // Apply smoothing to the rotated values
     float smoothed_x = prev_x * smoothing_factor + rotated_x * (1.0 - smoothing_factor);

--- a/keyboards/aki27/cocot46plus/cocot46plus.c
+++ b/keyboards/aki27/cocot46plus/cocot46plus.c
@@ -68,6 +68,38 @@ void pointing_device_init_kb(void) {
 }
 
 
+static double sin_degree(int16_t angle) {
+    double v[] = {
+        0,                           // 0
+        (sqrt(6) - sqrt(2)) / 4,     // 15
+        0.5,                         // 30
+        sqrt(2) / 2,                 // 45
+        sqrt(3) / 2,                 // 60
+    };
+    int i = angle < 0 ? -angle/15 : angle/15;
+    if (i > sizeof(v)/sizeof(v[0])) {
+        i = sizeof(v)/sizeof(v[0]) - 1;
+    }
+    return angle < 0 ? -v[i] : v[i];
+}
+
+
+static double cos_degree(int16_t angle) {
+    double v[] = {
+        1,                           // 0
+        (sqrt(6) + sqrt(2)) / 4,     // 15
+        sqrt(3) / 2,                 // 30
+        sqrt(2) / 2,                 // 45
+        0.5,                         // 60
+    };
+    int i = angle < 0 ? -angle/15 : angle/15;
+    if (i > sizeof(v)/sizeof(v[0])) {
+        i = sizeof(v)/sizeof(v[0]) - 1;
+    }
+    return v[i];
+}
+
+
 report_mouse_t pointing_device_task_kb(report_mouse_t mouse_report) {
     static float x_accumulator = 0.0;
     static float y_accumulator = 0.0;
@@ -78,9 +110,9 @@ report_mouse_t pointing_device_task_kb(report_mouse_t mouse_report) {
     float sensitivity_multiplier = 1.5; // Sensitivity adjustment multiplier
 
     // Apply rotation angle adjustment
-    double rad = (double)angle_array[cocot_config.rotation_angle] * (M_PI / 180) * -1;
-    float rotated_x = mouse_report.x * cos(rad) - mouse_report.y * sin(rad);
-    float rotated_y = mouse_report.x * sin(rad) + mouse_report.y * cos(rad);
+    int16_t angle = -angle_array[cocot_config.rotation_angle];
+    float rotated_x = mouse_report.x * cos_degree(angle) - mouse_report.y * sin_degree(angle);
+    float rotated_y = mouse_report.x * sin_degree(angle) + mouse_report.y * cos_degree(angle);
 
     // Apply smoothing to the rotated values
     float smoothed_x = prev_x * smoothing_factor + rotated_x * (1.0 - smoothing_factor);


### PR DESCRIPTION
Reduce firmware size by 210 bytes by eliminating sin and cos.

NOTE: If you accept this change, I would like you to merge https://github.com/aki27kbd/qmk_firmware/pull/9 first, because the change in this pull request hides the problem solved by https://github.com/aki27kbd/qmk_firmware/pull/9, leaving it confusing.